### PR TITLE
新規作成で真ん中から文字を打てるようにして文字のサイズを揃えた。

### DIFF
--- a/frontend/pages/new.vue
+++ b/frontend/pages/new.vue
@@ -253,10 +253,11 @@ const submitPost = async () => {
   max-height: 60vh;
   background-color: #FBF8EF;
   border: 1px solid #FFB433;
+  align-content: center;
   padding: 14px;
   border-radius: 6px;
   resize: none;
-  font-size: 16px;
+  font-size: 20px;
   line-height: 1.4;
   box-sizing: border-box;
   font-family: inherit;


### PR DESCRIPTION
## 概要
新規作成で真ん中から文字を打てるようにして文字のサイズを揃えた。
## 具体的にやったこと
新規作成の文字サイズを16px→20pxに。
align-content: center;を追加。
## 影響範囲
<!-- 影響出そうなところ、心配事 -->

## 補足
<!-- その他、メモしておきたい情報があればかく -->
新規作成の文字サイズもう少し大きくするかもという話あり
## 解決したissue
<!-- closeしたいissue番号をかく、margeされた後closeされる -->
close #
